### PR TITLE
Gracefully handle webhook failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/meinheld-gunicorn-flask:python3.8-alpine3.11
+FROM tiangolo/meinheld-gunicorn-flask:python3.9
 COPY ./doorman /app/doorman
 COPY requirements.txt /app
 RUN pip install --upgrade pip

--- a/doorman/app.py
+++ b/doorman/app.py
@@ -82,7 +82,11 @@ def lookup_card(card_number):
         if SUCCESS_WEBHOOK:
             webhook_data = {"_type": "CARD", "card_number": card_number}
             webhook_data.update(conn.response[0]['attributes'])
-            requests.post(SUCCESS_WEBHOOK, webhook_data)
+            try:
+                requests.post(SUCCESS_WEBHOOK, webhook_data)
+            except requests.RequestException as e:
+                app.logger.error("Exception while trying to send success webhook:")
+                app.logger.exception(e)
         return True
     else:
         app.logger.info("Card not found")
@@ -95,7 +99,11 @@ def lookup_pin(input_value):
             app.logger.info(f"Access granted by PIN for {ACCESS_PINS[pin]}")
             if SUCCESS_WEBHOOK:
                 webhook_data = {"_type": "PIN", "cn": ACCESS_PINS[pin]}
-                requests.post(SUCCESS_WEBHOOK, webhook_data)
+                try:
+                    requests.post(SUCCESS_WEBHOOK, webhook_data)
+                except requests.RequestException as e:
+                    app.logger.error("Exception while trying to send success webhook:")
+                    app.logger.exception(e)
             return True
     return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=1.1
-ldap3>=2.8
-requests==2.24.0
+Flask>=2.3.3
+ldap3>=2.9.1
+requests~=2.32.3
 #json_logging>=1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=2.3.3
+Flask>=2.2.5
 ldap3>=2.9.1
 requests~=2.32.3
 #json_logging>=1.2


### PR DESCRIPTION
If doorman is unable to complete a webhook during the request lifecycle, the stack trace causes a 500 error which in turn causes the door controller to reject access.